### PR TITLE
Fix: Image loading due to 404/mixed content

### DIFF
--- a/templates/advanced.html
+++ b/templates/advanced.html
@@ -9,13 +9,13 @@
 <p>These resources will help you to work towards getting your Advanced (full) licence, which will grant you full privileges such as a higher power limit, and the ability to operate in many other countries </p>
 <br>
 
-<a href="http://www.brats-qth.org/training/advanced/index.htm" target="_blank">
-<img src="http://www.brats-qth.org/training/graphics/bratslogo2.gif" height="100px">
+<a href="https://www.brats-qth.org/training/advanced/index.htm" target="_blank">
+<img src="https://www.brats-qth.org/training/graphics/bratslogo2.gif" height="100px">
 <p>Bredhurst Receiving and Transmitting Society</p></a>
 <br>
 
 <a href="http://www.g0mwt.org.uk/training/courses/advanced.htm" target="_blank">
-<img src="http://www.g0mwt.org.uk/training/courses/images/web-logo3.jpg" height="100px">
+<img src="https://unavatar.io/twitter/ChelmsfordARS" height="100px">
 <p>Chelmsford ARS</p></a>
 
 

--- a/templates/foundation.html
+++ b/templates/foundation.html
@@ -11,12 +11,12 @@
 <br>
 
 <a href="https://www.essexham.co.uk/train/foundation-slides/">
-<img src="https://pbs.twimg.com/profile_images/929987765558800384/OTUSR5UN_400x400.jpg" height="100px">
+<img src="https://unavatar.io/twitter/EssexHam" height="100px">
 <p>Essex Ham</p></a>
 <br>
 
 <a href="http://www.g0mwt.org.uk/training/courses/foundation.htm">
-<img src="http://www.g0mwt.org.uk/training/courses/images/web-logo3.jpg" height="100px">
+<img src="https://unavatar.io/twitter/ChelmsfordARS" height="100px">
 <p>Chelmsford Amateur Radio Society</p></a>
 
 

--- a/templates/intermediate.html
+++ b/templates/intermediate.html
@@ -11,12 +11,12 @@
 <br>
 
 <a href="http://www.cdarc.org.uk/downloads/training/Intermediate_slides_worksheet_order.pdf" target="_blank">
-<img src="http://www.cdarc.org.uk/images/Frame/3d_CDARC_Title.png" height="100px">
+<img src="https://unavatar.io/twitter/Cambridge_CDARC" height="100px">
 <p>Cambridge & District ARC</p></a>
 <br>
 
 <a href="http://www.g0mwt.org.uk/training/courses/intermediate.htm" target="_blank">
-<img src="http://www.g0mwt.org.uk/training/courses/images/web-logo3.jpg" height="100px">
+<img src="https://unavatar.io/twitter/ChelmsfordARS" height="100px">
 <p>Chelmsford ARS</p></a>
 
 </div>


### PR DESCRIPTION
Fixes loading of images;
- That can no longer be found (due to 404). Uses a third-party service to fetch profile image from Twitter.
- That causes mixed-content warnings (loading http images over https), using the same third-party service to fetch profile images from Twitter.
- Where a https version is available, but a http version is currently used causing a mixed-content warning

Updates a http link to https where https is available.

On the following pages;
- https://radiotutor.uk/l/F/course
- https://radiotutor.uk/l/I/course
- https://radiotutor.uk/l/AV/course

An alternative approach would be to serve the images from the same radiotutor origin.

Thank you for considering this PR.